### PR TITLE
feat: add Code Assistant Agent with explain, generate and detect-bugs capabilities

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,21 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.15.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -50,6 +65,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Dnet.bytebuddy.experimental=true</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/arvind/copilot/controller/CodeAssistantController.java
+++ b/src/main/java/com/arvind/copilot/controller/CodeAssistantController.java
@@ -1,0 +1,23 @@
+package com.arvind.copilot.controller;
+
+import com.arvind.copilot.model.AgentResponse;
+import com.arvind.copilot.model.CodeRequest;
+import com.arvind.copilot.service.CodeAssistantService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/agent")
+public class CodeAssistantController {
+
+    private final CodeAssistantService codeAssistantService;
+
+    public CodeAssistantController(CodeAssistantService codeAssistantService) {
+        this.codeAssistantService = codeAssistantService;
+    }
+
+    @PostMapping("/code")
+    public AgentResponse code(@RequestBody CodeRequest request) {
+        String reply = codeAssistantService.process(request.getType(), request.getCode());
+        return new AgentResponse(reply);
+    }
+}

--- a/src/main/java/com/arvind/copilot/model/CodeRequest.java
+++ b/src/main/java/com/arvind/copilot/model/CodeRequest.java
@@ -1,0 +1,12 @@
+package com.arvind.copilot.model;
+
+public class CodeRequest {
+    private String type;
+    private String code;
+
+    public String getType(){ return type;}
+    public void setType(String type){this.type=type;}
+    public String getCode(){return code;}
+    public void setCode(){this.code = code;}
+
+}

--- a/src/main/java/com/arvind/copilot/service/CodeAssistantService.java
+++ b/src/main/java/com/arvind/copilot/service/CodeAssistantService.java
@@ -1,0 +1,26 @@
+package com.arvind.copilot.service;
+
+import org.springframework.stereotype.Service;
+
+import com.arvind.copilot.llm.OpenAiClient;
+
+@Service
+public class CodeAssistantService {
+    private final OpenAiClient openAiCLient;
+    public CodeAssistantService(OpenAiClient openAiClient){
+        this.openAiCLient=openAiClient;
+    }
+    public String process(String type,String code){
+        String prompt=buildPrompt(type,code);
+        return openAiCLient.askLLM(prompt);
+    }
+    private String buildPrompt(String type, String code){
+        return switch(type){
+            case "explain" -> "Explain this code clearly:\n\n" + code;
+            case "generate" -> "Generate clean Java code for:\n\n" + code;
+            case "detect-bugs" -> "Find bugs in this code and explain each one:\n\n" + code;
+            default -> throw new IllegalArgumentException("Unknown type: " + type);
+        };
+    }
+
+}

--- a/src/test/java/com/arvind/copilot/service/CodeAssistantServiceTest.java
+++ b/src/test/java/com/arvind/copilot/service/CodeAssistantServiceTest.java
@@ -1,0 +1,62 @@
+package com.arvind.copilot.service;
+import com.arvind.copilot.llm.OpenAiClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CodeAssistantServiceTest {
+
+    @Mock
+    private OpenAiClient openAiClient;
+
+    @InjectMocks
+    private CodeAssistantService codeAssistantService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void shouldExplainCode() {
+        when(openAiClient.askLLM(contains("Explain"))).thenReturn("This method adds two numbers");
+
+        String result = codeAssistantService.process("explain", "public int add(int a, int b) { return a + b; }");
+
+        assertNotNull(result);
+        assertEquals("This method adds two numbers", result);
+        verify(openAiClient, times(1)).askLLM(anyString());
+    }
+
+    @Test
+    void shouldGenerateCode() {
+        when(openAiClient.askLLM(contains("Generate"))).thenReturn("public String reverse(String s) { return new StringBuilder(s).reverse().toString(); }");
+
+        String result = codeAssistantService.process("generate", "a method to reverse a string");
+
+        assertNotNull(result);
+        verify(openAiClient, times(1)).askLLM(anyString());
+    }
+
+    @Test
+    void shouldDetectBugs() {
+        when(openAiClient.askLLM(contains("bugs"))).thenReturn("Bug: division by zero when b is 0");
+
+        String result = codeAssistantService.process("detect-bugs", "public int divide(int a, int b) { return a / b; }");
+
+        assertNotNull(result);
+        verify(openAiClient, times(1)).askLLM(anyString());
+    }
+
+    @Test
+    void shouldThrowExceptionForUnknownType() {
+        assertThrows(IllegalArgumentException.class, () ->
+            codeAssistantService.process("unknown-type", "some code")
+        );
+    }
+}


### PR DESCRIPTION
Closes #37

## What's added
- New `/agent/code` endpoint
- Supports explain, generate and detect-bugs capabilities
- Unit tests for CodeAssistantService